### PR TITLE
IBX-9697: Fixed keys normalization

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -20,8 +20,10 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->useAttributeAsKey('group')
+            ->normalizeKeys(false)
             ->arrayPrototype()
                 ->useAttributeAsKey('name')
+                ->normalizeKeys(false)
                 ->arrayPrototype()
                     ->children()
                         ->scalarNode('type')


### PR DESCRIPTION
| :ticket: Issue | [IBX-9697](https://issues.ibexa.co/browse/IBX-9697)  |
|----------------|-----------|


#### Description:
Fixed keys normalization
Without this change, when you put string as a group then string was normalized so when you have dash '-' it was removed. These keys are used as components group, and in ibexa most of groups have dashes