### PR TITLE
Allowed adding runtime parameters in TemplateComponent

### DIFF
--- a/src/lib/Component/TemplateComponent.php
+++ b/src/lib/Component/TemplateComponent.php
@@ -40,6 +40,18 @@ class TemplateComponent implements ComponentInterface
      */
     public function render(array $parameters = []): string
     {
-        return $this->twig->render($this->template, array_merge($parameters + $this->parameters));
+        $parameters = $this->getParameters($parameters);
+
+        return $this->twig->render($this->template, $parameters);
+    }
+
+    /**
+     * @param array<mixed> $parameters
+     *
+     * @return array<mixed>
+     */
+    protected function getParameters(array $parameters): array
+    {
+        return $parameters + $this->parameters;
     }
 }

--- a/tests/bundle/Component/TemplateComponentTest.php
+++ b/tests/bundle/Component/TemplateComponentTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Tests\Bundle\TwigComponents\Component;
 
 use Ibexa\TwigComponents\Component\TemplateComponent;
@@ -8,7 +14,6 @@ use Twig\Environment;
 
 final class TemplateComponentTest extends TestCase
 {
-
     public function testRenderWithParameters(): void
     {
         $twig = $this->configureTwig([

--- a/tests/bundle/Component/TemplateComponentTest.php
+++ b/tests/bundle/Component/TemplateComponentTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Ibexa\Tests\Bundle\TwigComponents\Component;
+
+use Ibexa\TwigComponents\Component\TemplateComponent;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+
+final class TemplateComponentTest extends TestCase
+{
+
+    public function testRenderWithParameters(): void
+    {
+        $twig = $this->configureTwig([
+            '__parameter__' => false,
+        ]);
+
+        $component = new TemplateComponent(
+            $twig,
+            '__template__',
+            [
+                '__parameter__' => true,
+            ],
+        );
+
+        $component->render([
+            '__parameter__' => false,
+        ]);
+    }
+
+    public function testRenderWithoutParameters(): void
+    {
+        $twig = $this->configureTwig([
+            '__parameter__' => true,
+        ]);
+
+        $component = new TemplateComponent(
+            $twig,
+            '__template__',
+            [
+                '__parameter__' => true,
+            ],
+        );
+
+        $component->render();
+    }
+
+    /**
+     * @param array<mixed> $parameters
+     *
+     * @return \Twig\Environment|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function configureTwig(array $parameters): Environment
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->expects(self::once())
+            ->method('render')
+            ->with(
+                '__template__',
+                $parameters,
+            );
+
+        return $twig;
+    }
+}

--- a/tests/bundle/Component/TemplateComponentTest.php
+++ b/tests/bundle/Component/TemplateComponentTest.php
@@ -14,6 +14,23 @@ use Twig\Environment;
 
 final class TemplateComponentTest extends TestCase
 {
+    public function testRenderWithoutParameters(): void
+    {
+        $twig = $this->configureTwig([
+            '__parameter__' => true,
+        ]);
+
+        $component = new TemplateComponent(
+            $twig,
+            '__template__',
+            [
+                '__parameter__' => true,
+            ],
+        );
+
+        $component->render();
+    }
+
     public function testRenderWithParameters(): void
     {
         $twig = $this->configureTwig([
@@ -33,10 +50,11 @@ final class TemplateComponentTest extends TestCase
         ]);
     }
 
-    public function testRenderWithoutParameters(): void
+    public function testRenderWithNewParameter(): void
     {
         $twig = $this->configureTwig([
             '__parameter__' => true,
+            '__new_parameter__' => 'foo',
         ]);
 
         $component = new TemplateComponent(
@@ -47,7 +65,9 @@ final class TemplateComponentTest extends TestCase
             ],
         );
 
-        $component->render();
+        $component->render([
+            '__new_parameter__' => 'foo',
+        ]);
     }
 
     /**


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR adds `protected function getParameters(array $parameters)` to `TemplateComponent`, allowing for descending classes to obtain parameters in runtime (not through constructor), and based on parameters passed to the template.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
