### PR TITLE
Introduced AsTwigComponent attribute for autoconfiguration

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/ComponentPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ComponentPass.php
@@ -18,7 +18,7 @@ final class ComponentPass implements CompilerPassInterface
 {
     use PriorityTaggedServiceTrait;
 
-    public const TAG_NAME = 'ibexa.twig.component';
+    public const string TAG_NAME = 'ibexa.twig.component';
 
     public function process(ContainerBuilder $container): void
     {
@@ -42,7 +42,10 @@ final class ComponentPass implements CompilerPassInterface
                     );
                 }
                 $id = $tag['id'] ?? $id;
-                $registryDefinition->addMethodCall('addComponent', [$tag['group'], $id, $serviceReference]);
+                $registryDefinition->addMethodCall(
+                    'addComponent',
+                    [$tag['group'], $id, $serviceReference]
+                );
             }
         }
     }

--- a/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
+++ b/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\TwigComponents\DependencyInjection;
 
 use Ibexa\Bundle\TwigComponents\DependencyInjection\Compiler\ComponentPass;
+use Ibexa\Contracts\TwigComponents\Attribute\AsTwigComponent;
 use Ibexa\Contracts\TwigComponents\Exception\InvalidArgumentException;
 use Ibexa\TwigComponents\Component\ControllerComponent;
 use Ibexa\TwigComponents\Component\HtmlComponent;
@@ -56,6 +57,15 @@ final class IbexaTwigComponentsExtension extends Extension implements PrependExt
 
         $configuration = $this->processConfiguration(new Configuration(), $configs);
         $this->registerConfiguredComponents($configuration, $container);
+
+        $container->registerAttributeForAutoconfiguration(
+            AsTwigComponent::class,
+            function (Definition $definition, AsTwigComponent $attribute) {
+                $definition->addTag('ibexa.twig.component', [
+                    'group' => $attribute->group,
+                ]);
+            }
+        );
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
+++ b/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
@@ -60,7 +60,7 @@ final class IbexaTwigComponentsExtension extends Extension implements PrependExt
 
         $container->registerAttributeForAutoconfiguration(
             AsTwigComponent::class,
-            function (Definition $definition, AsTwigComponent $attribute) {
+            static function (Definition $definition, AsTwigComponent $attribute) {
                 $definition->addTag('ibexa.twig.component', [
                     'group' => $attribute->group,
                 ]);

--- a/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
+++ b/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
@@ -60,7 +60,7 @@ final class IbexaTwigComponentsExtension extends Extension implements PrependExt
 
         $container->registerAttributeForAutoconfiguration(
             AsTwigComponent::class,
-            static function (Definition $definition, AsTwigComponent $attribute) {
+            static function (Definition $definition, AsTwigComponent $attribute): void {
                 $definition->addTag('ibexa.twig.component', [
                     'group' => $attribute->group,
                 ]);

--- a/src/contracts/Attribute/AsTwigComponent.php
+++ b/src/contracts/Attribute/AsTwigComponent.php
@@ -2,6 +2,12 @@
 
 /**
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license   For full copyright and license information view LICENSE file distributed with this source code.
  */
 
@@ -14,5 +20,6 @@ final class AsTwigComponent
 {
     public function __construct(
         public string $group,
-    ) {}
+    ) {
+    }
 }

--- a/src/contracts/Attribute/AsTwigComponent.php
+++ b/src/contracts/Attribute/AsTwigComponent.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license   For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Ibexa\Contracts\TwigComponents\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class AsTwigComponent
+{
+    public function __construct(
+        public string $group,
+    ) {}
+}

--- a/src/contracts/Attribute/AsTwigComponent.php
+++ b/src/contracts/Attribute/AsTwigComponent.php
@@ -6,11 +6,6 @@
  */
 declare(strict_types=1);
 
-/**
- * @copyright Copyright (C) Ibexa AS. All rights reserved.
- * @license   For full copyright and license information view LICENSE file distributed with this source code.
- */
-
 namespace Ibexa\Contracts\TwigComponents\Attribute;
 
 use Attribute;

--- a/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Bundle\TwigComponents\DependencyInjection;
 
 use Ibexa\Bundle\TwigComponents\DependencyInjection\IbexaTwigComponentsExtension;
+use Ibexa\Tests\Bundle\TwigComponents\Fixtures\DummyComponent;
 use Ibexa\TwigComponents\Component\TemplateComponent;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -70,5 +71,20 @@ final class IbexaTwigComponentsExtensionTest extends AbstractExtensionTestCase
                 ],
             ],
         ]);
+    }
+
+    public function testAttributeCausesTagToBeAdded(): void
+    {
+        $this->container->register(DummyComponent::class, DummyComponent::class)
+            ->setAutowired(true)
+            ->setAutoconfigured(true);
+        $this->load();
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            DummyComponent::class,
+            'ibexa.twig.component',
+            ['group' => 'test_group']
+        );
     }
 }

--- a/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
@@ -75,7 +75,8 @@ final class IbexaTwigComponentsExtensionTest extends AbstractExtensionTestCase
 
     public function testAttributeCausesTagToBeAdded(): void
     {
-        $this->container->register(DummyComponent::class, DummyComponent::class)
+        $this->container
+            ->register(DummyComponent::class, DummyComponent::class)
             ->setAutowired(true)
             ->setAutoconfigured(true);
         $this->load();

--- a/tests/bundle/Fixtures/DummyComponent.php
+++ b/tests/bundle/Fixtures/DummyComponent.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\TwigComponents\Fixtures;
+
+use Ibexa\Contracts\TwigComponents\Attribute\AsTwigComponent;
+
+#[AsTwigComponent(group: 'test_group')]
+final class DummyComponent
+{
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Description:
Introduce possibility of using AsTwigComponent attribute to register class as a component

example:

```
#[AsTwigComponent(group: 'admin-ui-dashboard-all-tab-groups')]
class TestComponent implements ComponentInterface
{
```
#### For QA:
Check if there is possibility to register component by this attribute. For this to work, class which are marked as component must be a service and must implement ComponentInterface

#### Documentation:
Add to the documentation that we can now register component also by adding attribute `AsTwigComponent` 