### PR TITLE
IBX-10990: Added exception handling for missing required bundles

### DIFF
--- a/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
+++ b/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
@@ -17,6 +17,7 @@ use Ibexa\TwigComponents\Component\LinkComponent;
 use Ibexa\TwigComponents\Component\MenuComponent;
 use Ibexa\TwigComponents\Component\ScriptComponent;
 use Ibexa\TwigComponents\Component\TemplateComponent;
+use LogicException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -73,6 +74,14 @@ final class IbexaTwigComponentsExtension extends Extension implements PrependExt
 
     public function prepend(ContainerBuilder $container): void
     {
+        if (!$container->hasExtension('twig')) {
+            throw new LogicException('IbexaTwigComponentsBundle requires TwigBundle. Please enable it in your bundles.php file.');
+        }
+
+        if (!$container->hasExtension('twig_component')) {
+            throw new LogicException('IbexaTwigComponentsBundle requires TwigComponentBundle (symfony/ux-twig-component). Please enable it in your bundles.php file.');
+        }
+
         $this->prependDefaultConfiguration($container);
         $this->prependJMSTranslation($container);
     }

--- a/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
+++ b/src/bundle/DependencyInjection/IbexaTwigComponentsExtension.php
@@ -17,7 +17,6 @@ use Ibexa\TwigComponents\Component\LinkComponent;
 use Ibexa\TwigComponents\Component\MenuComponent;
 use Ibexa\TwigComponents\Component\ScriptComponent;
 use Ibexa\TwigComponents\Component\TemplateComponent;
-use LogicException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -74,14 +73,6 @@ final class IbexaTwigComponentsExtension extends Extension implements PrependExt
 
     public function prepend(ContainerBuilder $container): void
     {
-        if (!$container->hasExtension('twig')) {
-            throw new LogicException('IbexaTwigComponentsBundle requires TwigBundle. Please enable it in your bundles.php file.');
-        }
-
-        if (!$container->hasExtension('twig_component')) {
-            throw new LogicException('IbexaTwigComponentsBundle requires TwigComponentBundle (symfony/ux-twig-component). Please enable it in your bundles.php file.');
-        }
-
         $this->prependDefaultConfiguration($container);
         $this->prependJMSTranslation($container);
     }

--- a/src/bundle/IbexaTwigComponentsBundle.php
+++ b/src/bundle/IbexaTwigComponentsBundle.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\TwigComponents;
 
 use Ibexa\Bundle\TwigComponents\DependencyInjection\Compiler\ComponentPass;
+use LogicException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -16,6 +17,14 @@ final class IbexaTwigComponentsBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {
+        if (!$container->hasExtension('twig')) {
+            throw new LogicException('IbexaTwigComponentsBundle requires TwigBundle. Please enable it in your bundles.php file.');
+        }
+
+        if (!$container->hasExtension('twig_component')) {
+            throw new LogicException('IbexaTwigComponentsBundle requires TwigComponentBundle (symfony/ux-twig-component). Please enable it in your bundles.php file.');
+        }
+
         $container->addCompilerPass(new ComponentPass());
     }
 }

--- a/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
@@ -89,12 +89,7 @@ final class IbexaTwigComponentsExtensionTest extends AbstractExtensionTestCase
 
     public function testInvalidComponentTypeThrowsException(): void
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage(
-            'Unrecognized option "invalid_component" under "ibexa_twig_components.ibexa_twig_components.invalid_group'
-        );
-
-        $this->load([
+        $config = [
             'ibexa_twig_components' => [
                 'invalid_group' => [
                     'invalid_component' => [
@@ -103,7 +98,14 @@ final class IbexaTwigComponentsExtensionTest extends AbstractExtensionTestCase
                     ],
                 ],
             ],
-        ]);
+        ];
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(
+            'Unrecognized option "invalid_component" under "ibexa_twig_components.ibexa_twig_components.invalid_group'
+        );
+
+        $this->load($config);
     }
 
     public function testAttributeCausesTagToBeAdded(): void

--- a/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
@@ -11,11 +11,41 @@ namespace Ibexa\Tests\Bundle\TwigComponents\DependencyInjection;
 use Ibexa\Bundle\TwigComponents\DependencyInjection\IbexaTwigComponentsExtension;
 use Ibexa\Tests\Bundle\TwigComponents\Fixtures\DummyComponent;
 use Ibexa\TwigComponents\Component\TemplateComponent;
+use LogicException;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 final class IbexaTwigComponentsExtensionTest extends AbstractExtensionTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container->registerExtension(new class() extends Extension {
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+            }
+
+            public function getAlias(): string
+            {
+                return 'twig';
+            }
+        });
+
+        $this->container->registerExtension(new class() extends Extension {
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+            }
+
+            public function getAlias(): string
+            {
+                return 'twig_component';
+            }
+        });
+    }
+
     protected function getContainerExtensions(): array
     {
         return [new IbexaTwigComponentsExtension()];
@@ -94,5 +124,42 @@ final class IbexaTwigComponentsExtensionTest extends AbstractExtensionTestCase
                 'priority' => 100,
             ]
         );
+    }
+
+    public function testLoadThrowsExceptionIfTwigBundleIsNotEnabled(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('IbexaTwigComponentsBundle requires TwigBundle. Please enable it in your bundles.php file.');
+
+        // We create a new container builder without the twig extension for this test
+        $this->container = new ContainerBuilder();
+        foreach ($this->getContainerExtensions() as $extension) {
+            $this->container->registerExtension($extension);
+        }
+        $this->load();
+    }
+
+    public function testLoadThrowsExceptionIfTwigComponentBundleIsNotEnabled(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('IbexaTwigComponentsBundle requires TwigComponentBundle (symfony/ux-twig-component). Please enable it in your bundles.php file.');
+
+        // We create a new container builder without the twig_component extension for this test
+        $this->container = new ContainerBuilder();
+        $this->container->registerExtension(new class() extends Extension {
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+            }
+
+            public function getAlias(): string
+            {
+                return 'twig';
+            }
+        });
+
+        foreach ($this->getContainerExtensions() as $extension) {
+            $this->container->registerExtension($extension);
+        }
+        $this->load();
     }
 }

--- a/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaTwigComponentsExtensionTest.php
@@ -11,7 +11,6 @@ namespace Ibexa\Tests\Bundle\TwigComponents\DependencyInjection;
 use Ibexa\Bundle\TwigComponents\DependencyInjection\IbexaTwigComponentsExtension;
 use Ibexa\Tests\Bundle\TwigComponents\Fixtures\DummyComponent;
 use Ibexa\TwigComponents\Component\TemplateComponent;
-use LogicException;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -124,42 +123,5 @@ final class IbexaTwigComponentsExtensionTest extends AbstractExtensionTestCase
                 'priority' => 100,
             ]
         );
-    }
-
-    public function testLoadThrowsExceptionIfTwigBundleIsNotEnabled(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('IbexaTwigComponentsBundle requires TwigBundle. Please enable it in your bundles.php file.');
-
-        // We create a new container builder without the twig extension for this test
-        $this->container = new ContainerBuilder();
-        foreach ($this->getContainerExtensions() as $extension) {
-            $this->container->registerExtension($extension);
-        }
-        $this->load();
-    }
-
-    public function testLoadThrowsExceptionIfTwigComponentBundleIsNotEnabled(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('IbexaTwigComponentsBundle requires TwigComponentBundle (symfony/ux-twig-component). Please enable it in your bundles.php file.');
-
-        // We create a new container builder without the twig_component extension for this test
-        $this->container = new ContainerBuilder();
-        $this->container->registerExtension(new class() extends Extension {
-            public function load(array $configs, ContainerBuilder $container): void
-            {
-            }
-
-            public function getAlias(): string
-            {
-                return 'twig';
-            }
-        });
-
-        foreach ($this->getContainerExtensions() as $extension) {
-            $this->container->registerExtension($extension);
-        }
-        $this->load();
     }
 }

--- a/tests/bundle/IbexaTwigComponentsBundleTest.php
+++ b/tests/bundle/IbexaTwigComponentsBundleTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\TwigComponents;
 
+use Ibexa\Bundle\TwigComponents\DependencyInjection\Compiler\ComponentPass;
 use Ibexa\Bundle\TwigComponents\IbexaTwigComponentsBundle;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -76,15 +77,6 @@ final class IbexaTwigComponentsBundleTest extends TestCase
         $bundle = new IbexaTwigComponentsBundle();
         $bundle->build($container);
 
-        $passes = $container->getCompilerPassConfig()->getBeforeOptimizationPasses();
-        $found = false;
-        foreach ($passes as $pass) {
-            if ($pass instanceof \Ibexa\Bundle\TwigComponents\DependencyInjection\Compiler\ComponentPass) {
-                $found = true;
-                break;
-            }
-        }
-
-        self::assertTrue($found, 'ComponentPass should be registered');
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/tests/bundle/IbexaTwigComponentsBundleTest.php
+++ b/tests/bundle/IbexaTwigComponentsBundleTest.php
@@ -18,19 +18,17 @@ final class IbexaTwigComponentsBundleTest extends TestCase
 {
     public function testBuildThrowsExceptionIfTwigBundleIsNotEnabled(): void
     {
+        $container = new ContainerBuilder();
+        $bundle = new IbexaTwigComponentsBundle();
+
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('IbexaTwigComponentsBundle requires TwigBundle. Please enable it in your bundles.php file.');
 
-        $container = new ContainerBuilder();
-        $bundle = new IbexaTwigComponentsBundle();
         $bundle->build($container);
     }
 
     public function testBuildThrowsExceptionIfTwigComponentBundleIsNotEnabled(): void
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('IbexaTwigComponentsBundle requires TwigComponentBundle (symfony/ux-twig-component). Please enable it in your bundles.php file.');
-
         $container = new ContainerBuilder();
         $container->registerExtension(new class() extends Extension {
             public function load(array $configs, ContainerBuilder $container): void
@@ -44,6 +42,10 @@ final class IbexaTwigComponentsBundleTest extends TestCase
         });
 
         $bundle = new IbexaTwigComponentsBundle();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('IbexaTwigComponentsBundle requires TwigComponentBundle (symfony/ux-twig-component). Please enable it in your bundles.php file.');
+
         $bundle->build($container);
     }
 

--- a/tests/bundle/IbexaTwigComponentsBundleTest.php
+++ b/tests/bundle/IbexaTwigComponentsBundleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\TwigComponents;
+
+use Ibexa\Bundle\TwigComponents\IbexaTwigComponentsBundle;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+final class IbexaTwigComponentsBundleTest extends TestCase
+{
+    public function testBuildThrowsExceptionIfTwigBundleIsNotEnabled(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('IbexaTwigComponentsBundle requires TwigBundle. Please enable it in your bundles.php file.');
+
+        $container = new ContainerBuilder();
+        $bundle = new IbexaTwigComponentsBundle();
+        $bundle->build($container);
+    }
+
+    public function testBuildThrowsExceptionIfTwigComponentBundleIsNotEnabled(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('IbexaTwigComponentsBundle requires TwigComponentBundle (symfony/ux-twig-component). Please enable it in your bundles.php file.');
+
+        $container = new ContainerBuilder();
+        $container->registerExtension(new class() extends Extension {
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+            }
+
+            public function getAlias(): string
+            {
+                return 'twig';
+            }
+        });
+
+        $bundle = new IbexaTwigComponentsBundle();
+        $bundle->build($container);
+    }
+
+    public function testBuildSuccessIfBothBundlesAreEnabled(): void
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new class() extends Extension {
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+            }
+
+            public function getAlias(): string
+            {
+                return 'twig';
+            }
+        });
+        $container->registerExtension(new class() extends Extension {
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+            }
+
+            public function getAlias(): string
+            {
+                return 'twig_component';
+            }
+        });
+
+        $bundle = new IbexaTwigComponentsBundle();
+        $bundle->build($container);
+
+        $passes = $container->getCompilerPassConfig()->getBeforeOptimizationPasses();
+        $found = false;
+        foreach ($passes as $pass) {
+            if ($pass instanceof \Ibexa\Bundle\TwigComponents\DependencyInjection\Compiler\ComponentPass) {
+                $found = true;
+                break;
+            }
+        }
+
+        self::assertTrue($found, 'ComponentPass should be registered');
+    }
+}

--- a/tests/bundle/IbexaTwigComponentsBundleTest.php
+++ b/tests/bundle/IbexaTwigComponentsBundleTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\TwigComponents;
 
-use Ibexa\Bundle\TwigComponents\DependencyInjection\Compiler\ComponentPass;
 use Ibexa\Bundle\TwigComponents\IbexaTwigComponentsBundle;
 use LogicException;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
| :ticket: Issue | IBX-10990 |
|----------------|-----------|

#### Follow up for PRs: 
- https://github.com/ibexa/twig-components/pull/25

#### Description:
This PR aims to provide early warning that missing bundles might cause runtime issues when Twig Components are being rendered.

Without them, the errors are cryptic, like "expecting an end tag for block".

<img width="1046" height="865" alt="image" src="https://github.com/user-attachments/assets/8d676980-e3c2-447f-a321-47879b041dce" />

<img width="1046" height="865" alt="image" src="https://github.com/user-attachments/assets/9214813e-2f68-4166-afb9-bab713b8e63d" />

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
